### PR TITLE
Remove developer names from todos

### DIFF
--- a/docker/mlflow_tracking_server.Dockerfile
+++ b/docker/mlflow_tracking_server.Dockerfile
@@ -7,6 +7,6 @@ RUN pip install \
         pymysql==1.1.0 \
         cryptography==42.0.7
 
-# TODO(malyuka): Turn back to 7027 - once the networking bug is fixed
+# TODO: Turn back to 7027 - once the networking bug is fixed
 ENV TRACKING_SERVER_PORT=5000
 EXPOSE $TRACKING_SERVER_PORT

--- a/flops_manager_package/flops_manager/classes/apps/customer_facing_base.py
+++ b/flops_manager_package/flops_manager/classes/apps/customer_facing_base.py
@@ -17,7 +17,7 @@ class FLOpsCustomerFacingApp(FLOpsApp, abc.ABC):
             core=SlaCore(
                 customerID=self.customer_id,
                 names=SlaNames(
-                    # TODO(malyuka): investigate
+                    # TODO: investigate
                     # if this can lead to name collisions
                     # keep in mind: 1 observer for 1 user - so we could be fine
                     app_name=self.namespace,

--- a/flops_manager_package/flops_manager/classes/apps/project.py
+++ b/flops_manager_package/flops_manager/classes/apps/project.py
@@ -14,7 +14,7 @@ from flops_manager.utils.exceptions.types import FlOpsExceptionTypes
 from flops_manager.utils.sla.components import SlaComponentsWrapper, SlaCore, SlaDetails, SlaNames
 from flops_manager.utils.types import Application, PostTrainingSteps
 
-# TODO(malyuka): /Future Work: Add additional Pydantic checking:
+# TODO: /Future Work: Add additional Pydantic checking:
 # e.g.: training_rounds > 1
 #       min_..._clients > 1, etc.
 
@@ -60,7 +60,7 @@ class _TrainingConfiguration(BaseModel):
 
 
 class _ResourceConstraints(BaseModel):
-    # TODO(malyuka): Fine-tune these values. + incorporate them in the final Project component SLAs.
+    # TODO: Fine-tune these values. + incorporate them in the final Project component SLAs.
     memory: int = 100
     vcpus: int = 1
     storage: int = 0

--- a/flops_manager_package/flops_manager/classes/services/helper/mock_data_provider.py
+++ b/flops_manager_package/flops_manager/classes/services/helper/mock_data_provider.py
@@ -63,7 +63,7 @@ class MockDataProvider(FLOpsService):
                 self.mock_data_configuration.dataset_name,
                 str(self.mock_data_configuration.number_of_partitions),
                 self.mock_data_configuration.data_tag,
-                # TODO(malyuka): add ip (instance IP) option to specify where exactly
+                # TODO: add ip (instance IP) option to specify where exactly
                 # to send mock data to
             )
         )

--- a/flops_manager_package/flops_manager/classes/services/helper/trained_model.py
+++ b/flops_manager_package/flops_manager/classes/services/helper/trained_model.py
@@ -47,9 +47,9 @@ class TrainedModel(FLOpsService):
             ),
             details=SlaDetails(
                 rr_ip=self.ip,  # type: ignore
-                # TODO(malyuka): Need adjusting
+                # TODO: Need adjusting
                 resources=SlaResources(memory=200, vcpus=1, storage=0),
-                # TODO(malyuka): Revert back to just TRAINED_MODEL_PORT once the port bug is fixed.
+                # TODO: Revert back to just TRAINED_MODEL_PORT once the port bug is fixed.
                 port=f"8088:{TRAINED_MODEL_PORT}",
             ),
         )

--- a/flops_manager_package/flops_manager/classes/services/observatory/tracking_server/main.py
+++ b/flops_manager_package/flops_manager/classes/services/observatory/tracking_server/main.py
@@ -15,7 +15,7 @@ from flops_manager.utils.sla.components import (
 )
 from pydantic import AliasChoices, Field
 
-# TODO(malyuka): Return back to 7027 after the networking port bug is resolved.
+# TODO: Return back to 7027 after the networking port bug is resolved.
 TRACKING_SERVER_PORT = 5000
 
 
@@ -75,7 +75,7 @@ class TrackingServer(FLOpsService):
             details=SlaDetails(
                 rr_ip=self.ip,  # type: ignore
                 resources=SlaResources(memory=200, vcpus=1, storage=0),
-                # TODO(malyuka): Revert back to 7027 once the networking/port bug is fixed.
+                # TODO: Revert back to 7027 once the networking/port bug is fixed.
                 port=f"7027:{TRACKING_SERVER_PORT}",
             ),
         )

--- a/flops_manager_package/flops_manager/classes/services/project/aggregators/classic_aggregator.py
+++ b/flops_manager_package/flops_manager/classes/services/project/aggregators/classic_aggregator.py
@@ -107,7 +107,7 @@ class ClassicFLAggregator(FLOpsProjectService):
             ),
         )
 
-    # TODO(malyuka): /FUTURE WORK: Refactor the two methods a bit to reduce code duplication.
+    # TODO: /FUTURE WORK: Refactor the two methods a bit to reduce code duplication.
     @classmethod
     def handle_aggregator_failed(cls, aggregator_failed_msg: dict) -> None:
         logger.debug(aggregator_failed_msg)

--- a/flops_manager_package/flops_manager/classes/services/project/aggregators/root_aggregator.py
+++ b/flops_manager_package/flops_manager/classes/services/project/aggregators/root_aggregator.py
@@ -84,7 +84,7 @@ class RootFLAggregator(ClassicFLAggregator):
             ),
         )
 
-    # TODO(malyuka): /FUTURE WORK: Refactor the two methods a bit to reduce code duplication.
+    # TODO: /FUTURE WORK: Refactor the two methods a bit to reduce code duplication.
     @classmethod
     def handle_aggregator_failed(cls, aggregator_failed_msg: dict) -> None:
         logger.debug(aggregator_failed_msg)

--- a/flops_manager_package/flops_manager/classes/services/project/builders/base_builder.py
+++ b/flops_manager_package/flops_manager/classes/services/project/builders/base_builder.py
@@ -83,7 +83,7 @@ class FLOpsBaseImageBuilder(FLOpsProjectService, abc.ABC):
             ),
             details=SlaDetails(
                 resources=SlaResources(
-                    # TODO(malyuka): fine-tune -> Currently the Trained-Model Image Builder
+                    # TODO: fine-tune -> Currently the Trained-Model Image Builder
                     # has a flaky deployment behavior "NoActiveClustersWithCapacity" is shown
                     # but when undeploy and redeploy manually it works.
                     memory=0,  # 2000,

--- a/flops_manager_package/flops_manager/classes/services/project/builders/trained_model_builder.py
+++ b/flops_manager_package/flops_manager/classes/services/project/builders/trained_model_builder.py
@@ -12,7 +12,7 @@ from flops_manager.utils.types import PostTrainingSteps
 
 
 class TrainedModelImageBuilder(FLOpsBaseImageBuilder):
-    # TODO(malyuka): Change port back to 7027 once the networking/port bug has been fixed.
+    # TODO: Change port back to 7027 once the networking/port bug has been fixed.
     tracking_server_uri: str = Field(examples=["http://10.30.X.Y:5000"])
     run_id: str = Field(description="The MLflow run-id of the trained model")
 

--- a/flops_manager_package/flops_manager/classes/services/project/learners/termination.py
+++ b/flops_manager_package/flops_manager/classes/services/project/learners/termination.py
@@ -13,8 +13,8 @@ def handle_learner_failed(learner_failed_msg: dict) -> None:
     logger.debug(learner_failed_msg)
     flops_project_id = learner_failed_msg["flops_project_id"]
     # NOTE: The learners will be undeployed as part of the aggregation failure handling.
-    # TODO(malyuka): Decouple this.
+    # TODO: Decouple this.
 
-    # TODO(malyuka): By improving this code a couple of redundant DB calls can be omitted.
+    # TODO: By improving this code a couple of redundant DB calls can be omitted.
     aggregator_class = get_matching_aggregator_class_based_on_project_id(flops_project_id)
     aggregator_class.handle_aggregator_failed(learner_failed_msg)  # type: ignore

--- a/flops_manager_package/flops_manager/utils/common.py
+++ b/flops_manager_package/flops_manager/utils/common.py
@@ -9,7 +9,7 @@ def get_shortened_unique_id(id: str) -> str:
 
 def generate_ip(unique_id: str, object: BaseModel) -> str:
     # NOTE: These numerical gymnastics are intended to avoid IP collisions.
-    # TODO(malyuka): /Future work: this logic needs to be more bullet proof.
+    # TODO: /Future work: this logic needs to be more bullet proof.
     # I.e. we need to ask the OAK components for available IPs instead of conjuring one ourselves.
 
     unique_int = int(unique_id, 16) % 65536

--- a/image_builder_package/fl_image_builder/build_plans/fl_actors/images/devel_base_images.py
+++ b/image_builder_package/fl_image_builder/build_plans/fl_actors/images/devel_base_images.py
@@ -1,10 +1,13 @@
 # NOTE: We need a separate var for the repo due to max line length linting.
+# TODO: These examples require migration to the Oakestra GitHub organisation.
 _mnist_sklearn_ml_repo = "https://github.com/Malyuk-A/flops_ml_repo_mnist_sklearn"
-_cifar10_keras_ml_repo = "https://github.com/Malyuk-A/flops_ml_repo_cifar10_keras"
-_cifar10_pytorch_ml_repo = "https://github.com/Malyuk-A/flops_ml_repo_cifar10_pytorch"
+# TODO: These examples are outdated and require overhauls due to updated dependencies.
+# _cifar10_keras_ml_repo = "https://github.com/<...>/flops_ml_repo_cifar10_keras"
+# _cifar10_pytorch_ml_repo = "https://github.com/<...>/flops_ml_repo_cifar10_pytorch"
 
 DEVEL_BASE_IMAGES_MAPPING = {
     _mnist_sklearn_ml_repo: "ghcr.io/oakestra/addon-flops/baseimage-mnist-sklearn:latest",
-    _cifar10_keras_ml_repo: "ghcr.io/oakestra/addon-flops/baseimage-cifar10-keras:latest",
-    _cifar10_pytorch_ml_repo: "ghcr.io/oakestra/addon-flops/baseimage-cifar10-pytorch:latest",
+    # TODO: These examples are outdated and require overhauls due to updated dependencies.
+    # _cifar10_keras_ml_repo: "ghcr.io/oakestra/addon-flops/baseimage-cifar10-keras:latest",
+    # _cifar10_pytorch_ml_repo: "ghcr.io/oakestra/addon-flops/baseimage-cifar10-pytorch:latest",
 }

--- a/image_builder_package/fl_image_builder/build_plans/fl_actors/images/fl_aggregator/aggregator_management.py
+++ b/image_builder_package/fl_image_builder/build_plans/fl_actors/images/fl_aggregator/aggregator_management.py
@@ -99,7 +99,7 @@ def handle_aggregator(
             # i.e. all Learner responses fail but the Aggregator continues
             # to fast-forward through his training-rounds.)
             # More info: https://discuss.flower.ai/t/how-do-i-start-from-a-pre-trained-model/73/2
-            # TODO(malyuka): Add a check in the builder to verify that the user provided code
+            # TODO: Add a check in the builder to verify that the user provided code
             # (the get_params() method) can be properly transformed into Flower Parameters.
             # I.e. verify that the user provided code fits our FLOps requirements
             # (structural, methods, etc.)

--- a/image_builder_package/fl_image_builder/build_plans/fl_actors/images/fl_aggregator/learner_parts/main.py
+++ b/image_builder_package/fl_image_builder/build_plans/fl_actors/images/fl_aggregator/learner_parts/main.py
@@ -7,7 +7,7 @@ from learner_parts.model_manager import ClusterAggregatorModelManager
 from utils.aggregator_context import AggregatorContext
 
 
-# NOTE/TODO(malyuka): This is almost identical to the Learner Class in the fl_actors/images/fl_learner.
+# NOTE/TODO: This is almost identical to the Learner Class in the fl_actors/images/fl_learner.
 # Maybe move this into the flops_utils lib and share the code
 # The only change necessary is to add an optional input param
 # - (special) ModelManager object instance (necessary for the CAg)

--- a/image_builder_package/fl_image_builder/image_management.py
+++ b/image_builder_package/fl_image_builder/image_management.py
@@ -34,7 +34,7 @@ def build_image(
     platforms = " ".join(
         [f"--platform {platform.value}" for platform in context.supported_platforms]
     )
-    # TODO(malyuka): read further about buildah options/flags - might improve the build further.
+    # TODO: read further about buildah options/flags - might improve the build further.
     build_cmd = " ".join(
         (
             "buildah build",

--- a/mock_data_provider_package/mock_data_provider/data_loader.py
+++ b/mock_data_provider_package/mock_data_provider/data_loader.py
@@ -8,7 +8,7 @@ from mock_data_provider.data_sender import send_data_to_ml_data_server
 def load_and_send_data_to_server() -> None:
     logger.info("Start loading dataset")
 
-    # NOTE/TODO(malyuka):/Future Work
+    # NOTE/TODO:/Future Work
     #
     # Currently we are only loading the training part of the data not the test part.
     # Because we currently do not differentiate between test and training data.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ line-length = 100
 
 [tool.ruff.lint]
 extend-select = [
-    "TD",  # todos
     "I",  # isort
 ]
 ignore = [


### PR DESCRIPTION
Partially resolves this: https://github.com/oakestra/addon-FLOps/issues/20

The reason why my name was explicitly mention next to the TODOs was a requirement by the ruff linter.
We had this active back in my previous job, so that it required you to mention a specific developer for each TODO.
This makes sense in a medium/large team. FLOps so far was a one man work, thus I am removing it.
In addition I am adding comments to signal that some examples (that were hosted on my personal GitHub account) are deprecated and require migration to the official Oakestra project as well as a general refactoring to be compatible with the latest dependency changes. (https://github.com/oakestra/addon-FLOps/issues/10 & https://github.com/oakestra/addon-FLOps/issues/9)